### PR TITLE
Fix errors in metrics for --meter {time,perf}

### DIFF
--- a/utility/perfreport.py
+++ b/utility/perfreport.py
@@ -37,13 +37,9 @@ def process_perf_lines(lines):
                 mname, unique_suffix_id = gen_unique_metrix_name(bench_metrics, values[1], unique_suffix_id)
                 bench_metrics[mname] = float(values[0])
     
-    if(warmup_rep > 0):
-        for key in bench_metrics:
-            bench_metrics[key] = (bench_metrics[key] - warmup_metrics[key]) / (bench_rep - warmup_rep)
-    else:
-        for key in bench_metrics:
-            bench_metrics[key] = (bench_metrics[key]) / (bench_rep)
-        
+    for key in bench_metrics:
+        bench_metrics[key] = (bench_metrics[key]) / (bench_rep)
+    
     return bench_metrics
 
 

--- a/utility/rbench.py
+++ b/utility/rbench.py
@@ -214,10 +214,9 @@ def run_bench(config, rvm, meter, warmup_rep, bench_rep, source, rargs, bench_lo
         lines = [line.strip() for line in open(perf_tmp)]
         metrics = process_perf_lines(lines)
         #os.remove(perf_tmp)
-        metrics['time'] = (bench_t - warmup_t) * 1000 / bench_rep
     elif meter == 'time':
         metrics = {}
-        metrics['time'] = (bench_t - warmup_t) * 1000 / bench_rep
+        metrics['time'] = bench_t * 1000 / bench_rep
     else: #system.time
         metrics = {}
         metrics['user'] = (bench_rtimes[0] - warmup_rtimes[0]) * 1000 / bench_rep


### PR DESCRIPTION
This makes --meter {time,perf} report only the benchmark run metrics,
not the difference between benchmark run and warmup run metrics.

fixes #5
