### PR TITLE
Remove redundant exception catching

### DIFF
--- a/utility/rbench.py
+++ b/utility/rbench.py
@@ -317,9 +317,6 @@ def main():
         except IOError as e:
           print >>sys.stderr, "I/O error({0}): {1}".format(e.errno, e.strerror)
           print >>sys.stderr, "Some of the benchmark data could not be logged!"
-        except Exception as e:
-            print e;
-            sys.exit(1)
         finally:
             os.chdir(cur_dir)
 


### PR DESCRIPTION
Catching an exception and just printing the message is less useful than
letting it go uncaught and cause the stack trace to be printed.
