### PR TITLE
Various improvements for Rho benchmarking

### DIFF
--- a/utility/rbench.py
+++ b/utility/rbench.py
@@ -54,7 +54,7 @@ def parse_args(rvms, warmup_rep, bench_rep):
                          perf: Linux perf, only available on Linux platform;
                          system.time: measure the time use R system.time() (Inside R process)''')
     parser.add_argument('--rvm', choices=rvms, default=rvms[0],
-                        help='R VM used for the benchmark. Defined in rbench.cfg. Default is '+rvms[1])
+                        help='R VM used for the benchmark. Defined in rbench.cfg. Default is '+rvms[0])
     parser.add_argument('--warmup_rep', default=warmup_rep, type=int,
                         help='The number of repetition to execute run() in warmup. Default is %d' % warmup_rep)
     parser.add_argument('--bench_rep', default=bench_rep, type=int,

--- a/utility/rbench.py
+++ b/utility/rbench.py
@@ -317,9 +317,6 @@ def main():
         except IOError as e:
           print >>sys.stderr, "I/O error({0}): {1}".format(e.errno, e.strerror)
           print >>sys.stderr, "Some of the benchmark data could not be logged!"
-        except Exception as e:
-            print e;
-            sys.exit(1)
         finally:
             os.chdir(cur_dir)
 

--- a/utility/rbench.py
+++ b/utility/rbench.py
@@ -107,7 +107,7 @@ def parse_args(rvms, warmup_rep, bench_rep):
 
 '''Return a dictionary'''
 def run_bench(config, rvm, meter, warmup_rep, bench_rep, source, rargs, bench_log):
-    perf_cmd = config.get('GENERAL', 'PERF_CMD')
+    perf_cmd = config.get('GENERAL', 'PERF_CMD').split()
     perf_tmp = config.get('GENERAL', 'PERF_TMP')
     rcmd = config.get(rvm, 'CMD')
     rcmd_args = config.get(rvm, 'ARGS')
@@ -121,9 +121,9 @@ def run_bench(config, rvm, meter, warmup_rep, bench_rep, source, rargs, bench_lo
         use_system_time = 'FALSE'
 
     if meter == 'perf':
-        warmup_cmd = [perf_cmd, rcmd, rcmd_args, harness, harness_args,
+        warmup_cmd = perf_cmd + [rcmd, rcmd_args, harness, harness_args,
                       use_system_time, str(warmup_rep), source, rargs]
-        bench_cmd = [perf_cmd, rcmd, rcmd_args, harness, harness_args,
+        bench_cmd = perf_cmd + [rcmd, rcmd_args, harness, harness_args,
                      use_system_time, str(warmup_rep+bench_rep), source, rargs]
     else: #default python
         warmup_cmd = [rcmd, rcmd_args, harness, harness_args,


### PR DESCRIPTION
Some fixes to run Rho benchmarks.

The `--config` option is used by the Rho benchmark script to configure the Rho RVM with the benchmark harness.
